### PR TITLE
fix: prevent poison burst-death around the level-up pause

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -608,6 +608,15 @@ export default class GameScene extends Phaser.Scene {
         this.physics.pause();
         this.isPaused = true;
 
+        // Freeze the player's status-effect timers so poison/burn ticks don't
+        // accumulate or fire while the game is paused for power-up selection.
+        this.player?.pause();
+
+        // Pause tweens so in-flight enemy AoE warnings (which apply damage/poison
+        // in their onComplete) don't resolve while the game is paused. Otherwise
+        // damage lands during the pause and dumps all at once on resume.
+        this.tweens.pauseAll();
+
         // Show power-ups when the game is paused
         this.showPowerUps();
 
@@ -645,6 +654,15 @@ export default class GameScene extends Phaser.Scene {
         // Resume the game physics
         this.physics.resume();
         this.isPaused = false;
+
+        // Resume tweens paused in pauseGame().
+        this.tweens.resumeAll();
+
+        // Resume the player's status effects. Tick timers (lastTick) and durations
+        // are intentionally left untouched so poison/burn continue exactly where
+        // they left off — the paused period simply doesn't count, no time is added
+        // or skipped.
+        this.player?.resume();
 
         this.hidePowerUps();
 


### PR DESCRIPTION
## 문제
독 마법사(PoisonWizard)가 등장한 뒤, 독 장판 위에서 레벨업 파워업 선택으로 일시정지되면, 일시정지가 걸리거나 풀리는 순간 독 데미지가 몰아쳐 즉사하는 경우가 있었습니다.

## 원인
적 AoE 공격은 데미지/상태이상을 **tween의 `onComplete`** 에서 적용합니다. 그런데 `pauseGame()`은 physics와 일부 timer만 멈추고 **tween과 플레이어 상태이상 처리는 멈추지 않았습니다.**

- 일시정지 중에도 진행 중이던 독 장판 경고 tween이 완료되며 독/데미지가 계속 들어옴
- 반면 독 tick(`updateStatusEffects`)은 `isPaused`로 막혀 duration이 만료되지 않고 얼어붙음
- 일시정지가 풀리는 순간 → 밀려있던 tween 완료 + 정렬된 여러 stack이 한꺼번에 tick → "파바박" 즉사

## 수정
- `pauseGame()`: `this.tweens.pauseAll()` + `this.player.pause()` 로 일시정지 중 데미지/독이 들어오지 않게 함
- `resumeGame()`: `this.tweens.resumeAll()` + `this.player.resume()` 로 재개

상태이상 tick 타이머(`lastTick`)와 duration은 **손대지 않아** 일시정지 기간만 정확히 제외되고 독 타이밍이 왜곡되지 않습니다. 독 스택(중첩)은 의도대로 유지됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)